### PR TITLE
fix: fixed react-scripts watcher for client container

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,8 +1,8 @@
 FROM node:12.21.0
-WORKDIR  .
-COPY package.json .
-RUN npm install --silent
-RUN npm install react-scripts@3.4.1 -g --silent
-COPY . .
+WORKDIR  /app
+COPY package.json /app
+RUN npm install
+# RUN npm install react-scripts@3.4.1 -g --silent
+COPY . /app
 EXPOSE 3000
 CMD ["npm", "run", "dev"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,11 @@ services:
       - 3000:3000
     # react-scripts start needs to open browser
     stdin_open: true
+    # react-scripts watcher needs to watch for local changes to reload the app
+    volumes:
+      - ./client/src:/app/src:ro
+      - ./client/package.json:/app/package.json:ro
+      - ./client/package-lock.json:/app/package-lock.json:ro
 
   server:
     container_name: server

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -3,5 +3,5 @@ WORKDIR  /app
 COPY package.json /app
 RUN npm install
 COPY . /app
-CMD ["npm", "run", "dev"]
 EXPOSE 5000 
+CMD ["npm", "run", "dev"]

--- a/server/src/Dockerfile
+++ b/server/src/Dockerfile
@@ -1,7 +1,0 @@
-FROM node:14
-WORKDIR .
-COPY package.json .
-RUN npm install
-COPY . .
-EXPOSE 5000
-CMD ["npm", "run", "dev"]


### PR DESCRIPTION
- problem: would not rerun the watcher for client on react change
- solution: share the volume where code changes are made or modules are installed with container so it can sync the changes

- SELF NOTE: also made sure that there was no memory leak when the watcher was reran in the container for client